### PR TITLE
fixed broken and unmaintained mkdirp-dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var execFileSync = require('child_process').execFileSync;
 var sizeOf = require('image-size');
-var mkdirp = require('mkdirp-promise');
+var mkdirp = require('mkdirp')
 var rimraf = require('rimraf-then');
 var fs = require('fs');
 var path = require('path');


### PR DESCRIPTION
As stated at https://www.npmjs.com/package/mkdirp-promise:

> The package "mkdir-promise" is broken and no longer maintained. 'mkdirp' itself supports promises now, please switch to that.